### PR TITLE
Adds format support for strings (url, uuid, email)

### DIFF
--- a/packages/test-app/src/server.ts
+++ b/packages/test-app/src/server.ts
@@ -215,6 +215,11 @@ const router = t.router({
             .query(() => {
                 return "It's an input";
             }),
+        emailTextInput: t.procedure
+            .input(z.object({ email: z.string().email("Bad email") }))
+            .query(({ input }) => {
+                return "It's good";
+            }),
     }),
 
     anErrorThrowingRoute: t.procedure

--- a/packages/trpc-panel/package.json
+++ b/packages/trpc-panel/package.json
@@ -79,6 +79,7 @@
   },
   "dependencies": {
     "@rollup/plugin-terser": "^0.2.0",
+    "ajv-formats": "^2.1.1",
     "fs": "^0.0.1-security",
     "path": "^0.12.7",
     "rollup-plugin-terser": "^7.0.2",

--- a/packages/trpc-panel/src/react-app/components/form/ProcedureForm/index.tsx
+++ b/packages/trpc-panel/src/react-app/components/form/ProcedureForm/index.tsx
@@ -17,6 +17,7 @@ import { RequestResult } from "./RequestResult";
 import { CollapsableSection } from "src/react-app/components/CollapsableSection";
 import { CloseIcon } from "src/react-app/components/icons/CloseIcon";
 import { ObjectField } from "src/react-app/components/form/fields/ObjectField";
+import { fullFormats } from "ajv-formats/dist/formats";
 
 const TRPCErrorSchema = z.object({
     shape: z.object({
@@ -90,7 +91,9 @@ export function ProcedureForm({
         reset: resetForm,
         handleSubmit,
     } = useForm({
-        resolver: ajvResolver(procedure.inputSchema as any),
+        resolver: ajvResolver(procedure.inputSchema as any, {
+            formats: fullFormats,
+        }),
         defaultValues: defaultFormValuesForNode(procedure.node),
     });
 


### PR DESCRIPTION
Previously `react-hook-form` would error because of an unsupported error format when using `z.string().email()` (or uuid / url). 

This PR adds all supported format validations from `ajv-formats` (which may differ slightly from actual zod email formats).