### PR TITLE
now uses : 'none' to prevent issues with zodToJsonSchema

### DIFF
--- a/packages/trpc-panel/src/parse/parseProcedure.ts
+++ b/packages/trpc-panel/src/parse/parseProcedure.ts
@@ -65,7 +65,10 @@ function nodeAndInputSchemaFromInputs(
   if (!inputs.length) {
     return {
       parseInputResult: "success",
-      schema: zodToJsonSchema(emptyZodObject, { errorMessages: true }),
+      schema: zodToJsonSchema(emptyZodObject, {
+        errorMessages: true,
+        $refStrategy: "none",
+      }),
       node: inputParserMap["zod"](emptyZodObject, {
         path: [],
         options,
@@ -84,7 +87,10 @@ function nodeAndInputSchemaFromInputs(
 
   return {
     parseInputResult: "success",
-    schema: zodToJsonSchema(input as any, { errorMessages: true }), //
+    schema: zodToJsonSchema(input as any, {
+      errorMessages: true,
+      $refStrategy: "none",
+    }), //
     node: zodSelectorFunction((input as any)._def, {
       path: [],
       options,


### PR DESCRIPTION
closes #71 and #43 