### PR TITLE
fix: Merge zod object inputs

### DIFF
--- a/packages/dev-app/src/router.ts
+++ b/packages/dev-app/src/router.ts
@@ -31,6 +31,23 @@ const postsRouter = createTRPCRouter({
         text: input.text,
       };
     }),
+  createNestedPost: procedure
+    .input(
+      z.object({
+        text: z.string(),
+      })
+    )
+    .input(
+      z.object({
+        title: z.string(),
+      })
+    )
+    .mutation(({ input }) => {
+      return {
+        id: "aoisdjfoasidjfasodf",
+        text: input.text,
+      };
+    }),
 });
 
 export const appRouter = createTRPCRouter({

--- a/packages/trpc-panel/package.json
+++ b/packages/trpc-panel/package.json
@@ -84,7 +84,6 @@
     "tslib": "^2.4.1",
     "typescript": "^4.9.3",
     "url": "^0.11.0",
-    "zod": "^3.19.1",
     "zustand": "^4.1.5"
   },
   "dependencies": {

--- a/packages/trpc-panel/src/parse/parseProcedure.ts
+++ b/packages/trpc-panel/src/parse/parseProcedure.ts
@@ -73,10 +73,11 @@ function nodeAndInputSchemaFromInputs(
       }),
     };
   }
+
+  let input = inputs[0];
   if (inputs.length !== 1) {
-    return { parseInputResult: "failure" };
+    input = inputs.reduce((acc, input) => (acc as any).merge(input), emptyZodObject);
   }
-  const input = inputs[0];
   const iType = inputType(input);
   if (iType == "unsupported") {
     return { parseInputResult: "failure" };

--- a/packages/trpc-panel/src/parse/parseProcedure.ts
+++ b/packages/trpc-panel/src/parse/parseProcedure.ts
@@ -82,8 +82,6 @@ function nodeAndInputSchemaFromInputs(
     return { parseInputResult: "failure" };
   }
 
-  let input = inputs[0];
-
   if (inputs.length > 1) {
     const allInputsAreZodObjects = inputs.every(
       (input) => input instanceof z.ZodObject
@@ -97,6 +95,7 @@ function nodeAndInputSchemaFromInputs(
       emptyZodObject
     );
   }
+
   const iType = inputType(input);
   if (iType == "unsupported") {
     return { parseInputResult: "failure" };

--- a/packages/trpc-panel/src/parse/parseProcedure.ts
+++ b/packages/trpc-panel/src/parse/parseProcedure.ts
@@ -75,8 +75,24 @@ function nodeAndInputSchemaFromInputs(
   }
 
   let input = inputs[0];
-  if (inputs.length !== 1) {
-    input = inputs.reduce((acc, input) => (acc as any).merge(input), emptyZodObject);
+  if (inputs.length < 1) {
+    return { parseInputResult: "failure" };
+  }
+
+  let input = inputs[0];
+
+  if (inputs.length > 1) {
+    const allInputsAreZodObjects = inputs.every(
+      (input) => input instanceof z.ZodObject
+    );
+    if (!allInputsAreZodObjects) {
+      return { parseInputResult: "failure" };
+    }
+
+    input = inputs.reduce(
+      (acc, input: z.AnyZodObject) => (acc as z.AnyZodObject).merge(input),
+      emptyZodObject
+    );
   }
   const iType = inputType(input);
   if (iType == "unsupported") {


### PR DESCRIPTION
Continuing the work on #64 , this first verifies that each of the input is a zod object before attempting to merge it. This will also fix #78.

I had to remove zod as a dependency, since having it both as a dependency and peer, causes the prototype on the inputs to be undefined. This meant, I couldn't use (input instanceOf z.ZodObject). That's discussed a bit more here - https://github.com/colinhacks/zod/issues/2241

Should I write a test for this ?