### PR TITLE
fix: .d.ts type error

### DIFF
--- a/packages/trpc-panel/package.json
+++ b/packages/trpc-panel/package.json
@@ -4,18 +4,16 @@
   "description": "UI for testing tRPC backends",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
-  "typings": "lib/src/index.d.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watchAll",
-    "build": "npx rollup --bundleConfigAsCjs --config rollup.config.js",
+    "build": "npx rollup --config rollup.config.mjs",
     "dev": "rollup --config rollup.config.js --watch --bundleConfigAsCjs"
   },
   "author": "",
   "license": "ISC",
   "exports": {
     ".": {
-      "types": "./lib/src/index.d.ts",
       "import": "./lib/index.mjs",
       "require": "./lib/index.js",
       "default": "./lib/index.js"
@@ -74,6 +72,7 @@
     "react-hotkeys-hook": "^4.0.6",
     "rollup": "^3.7.4",
     "rollup-plugin-copy": "^3.4.0",
+    "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-livereload": "^2.0.5",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-serve": "^2.0.1",

--- a/packages/trpc-panel/src/render.ts
+++ b/packages/trpc-panel/src/render.ts
@@ -1,5 +1,5 @@
 import { Router } from "@trpc/server";
-import fs from "fs";
+import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
 import {

--- a/packages/trpc-panel/tsconfig.buildPanel.json
+++ b/packages/trpc-panel/tsconfig.buildPanel.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "declaration": false,
+    "noEmit": true
+  },
   "exclude": [
     "src/react-app",
   ], 

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,7 +778,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13", "@jridgewell/sourcemap-codec@^1.4.15":
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
@@ -5937,6 +5937,13 @@ magic-string@^0.27.0:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.13"
 
+magic-string@^0.30.0:
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.1.tgz#ce5cd4b0a81a5d032bd69aab4522299b2166284d"
+  integrity sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -7675,6 +7682,15 @@ rollup-plugin-copy@^3.4.0:
     fs-extra "^8.1.0"
     globby "10.0.1"
     is-plain-object "^3.0.0"
+
+rollup-plugin-dts@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-5.3.0.tgz#80a95988002f188e376f6db3b7e2f53679168957"
+  integrity sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==
+  dependencies:
+    magic-string "^0.30.0"
+  optionalDependencies:
+    "@babel/code-frame" "^7.18.6"
 
 rollup-plugin-livereload@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
In TypeScript project without skipLibCheck, it will throw error
```
Cannot find module '@src/parse/parseNodeTypes' or its corresponding type declarations.ts(2307)
```

Also, https://github.com/iway1/trpc-panel/pull/51 this is wrong.
According to https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing, the only way to correct provide types for both Node ESM and CJS is to have two separate declaration files, so we need to generate .d.mts and .d.cts upon build.

So I bundle .d.ts to generate lib/index.d.ts and lib/index.d.mts