### PR TITLE
fix(DescriptionSection): remove dangling character

### DIFF
--- a/packages/trpc-panel/src/react-app/components/form/ProcedureForm/DescriptionSection.tsx
+++ b/packages/trpc-panel/src/react-app/components/form/ProcedureForm/DescriptionSection.tsx
@@ -56,7 +56,7 @@ function DocumentationSubsection({
 }) {
   return (
     <div className="flex flex-col space-y-2">
-      <FormLabel>{title}</FormLabel>ƒ
+      <FormLabel>{title}</FormLabel>
       <span className="text-sm text-gray-500">{children}</span>
     </div>
   );


### PR DESCRIPTION
I think there was a unnecessary character introduced in https://github.com/iway1/trpc-panel/commit/98fba514ebe908d8b70276bd7deee3bd7cf1864b#diff-3d1199da4832be7027ff79536aa455ffecec6b52ef98fda6da97676aa41884ffR59