### PR TITLE
feat: passing options to zod-to-json-schema

### DIFF
--- a/packages/trpc-panel/src/parse/parseProcedure.ts
+++ b/packages/trpc-panel/src/parse/parseProcedure.ts
@@ -68,6 +68,7 @@ function nodeAndInputSchemaFromInputs(
       schema: zodToJsonSchema(emptyZodObject, {
         errorMessages: true,
         $refStrategy: "none",
+        ...options.zodToJsonSchema,
       }),
       node: inputParserMap["zod"](emptyZodObject, {
         path: [],
@@ -90,6 +91,7 @@ function nodeAndInputSchemaFromInputs(
     schema: zodToJsonSchema(input as any, {
       errorMessages: true,
       $refStrategy: "none",
+      ...options.zodToJsonSchema,
     }), //
     node: zodSelectorFunction((input as any)._def, {
       path: [],

--- a/packages/trpc-panel/src/parse/parseRouter.ts
+++ b/packages/trpc-panel/src/parse/parseRouter.ts
@@ -4,6 +4,7 @@ import { Router as TRPCRouter } from "@trpc/server";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { logParseError } from "./parseErrorLogs";
 import { ParsedProcedure, parseProcedure } from "./parseProcedure";
+import type { Options as ZodToJsonSchemaOptions } from "zod-to-json-schema/src/Options";
 
 export type JSON7SchemaType = ReturnType<typeof zodToJsonSchema>;
 
@@ -64,6 +65,7 @@ function parseRouter(
 export type TrpcPanelExtraOptions = {
   logFailedProcedureParse?: boolean;
   transformer?: "superjson";
+  zodToJsonSchema?: Partial<Pick<ZodToJsonSchemaOptions, "$refStrategy">>;
 };
 
 export function parseRouterWithOptions(


### PR DESCRIPTION
Allows overriding `$refStrategy` option passed to zod-to-json-schema, and potentially other options in the future if desired

However, it might be better to remove the default `$refStrategy: "none"` and use the option passing provided by this PR to set it when needed, rather than overriding an override.