### PR TITLE
fix: Import named zustand create function

### DIFF
--- a/packages/trpc-panel/src/react-app/components/contexts/SearchStore.tsx
+++ b/packages/trpc-panel/src/react-app/components/contexts/SearchStore.tsx
@@ -1,4 +1,4 @@
-import create from "zustand";
+import { create } from "zustand";
 
 (()=>{
   // ssr for dev app


### PR DESCRIPTION
Fixes warning in console from zustand. The default export is deprecated. Luckily it's just re-exported on the named 'create' export so the fix was super simple.